### PR TITLE
replacing json.dumps with flask jsonify helper wrapper

### DIFF
--- a/sensugrid.py
+++ b/sensugrid.py
@@ -12,6 +12,7 @@ from concurrent.futures import as_completed
 from flask import Flask
 from flask import render_template
 from flask import abort
+from flask import jsonify
 
 from reverseproxied import ReverseProxied
 from gridcheck import check_connection
@@ -250,7 +251,7 @@ def healthcheck():
             retdata[dc['name']]['error'] = 'True'
         ret.append(retdata)
 
-    return json.dumps(ret)
+    return jsonify(ret)
 
 
 @app.template_filter('color_for_event')


### PR DESCRIPTION
Hi Alex,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using `json.dumps()` instead of flask `jsonify()`.

According to this Stackoverflow article (https://stackoverflow.com/questions/7907596/json-dumps-vs-flask-jsonify), the jsonify() function in flask returns a flask.Response() object that already has the appropriate content-type header 'application/json' for use with json responses. It also has support for handling multiple args / kwargs, including lists. Hopefully, you'll find this PR useful.

Bento flagged 2 other issues related to unsafe loading of yaml files and possible Python3 compatibility problem in griddata.py:149, but I didn't want to touch those issues in this PR. If you are interested,  feel free download and give Bento a try (https://bento.dev).